### PR TITLE
add hash code to attributes

### DIFF
--- a/src/main/groovy/edu/oregonstate/mist/locations/core/Attributes.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/locations/core/Attributes.groovy
@@ -23,4 +23,15 @@ class Attributes {
     String campus
     String type // used for searching. values: building, dining.
     Map<Integer, List<DayOpenHours>> openHours = new HashMap<Integer, List<DayOpenHours>>()
+    int getHashCode() {
+        int result
+        result = (name != null ? name.hashCode() : 0)
+        result = 31 * result + (abbreviation != null ? abbreviation.hashCode() : 0)
+        result = 31 * result + (website != null ? website.hashCode() : 0)
+        result = 31 * result + (address != null ? address.hashCode() : 0)
+        result = 31 * result + (city != null ? city.hashCode() : 0)
+        result = 31 * result + (telephone != null ? telephone.hashCode() : 0)
+
+        Math.abs(result)
+    }
 }


### PR DESCRIPTION
Due to the way ES indexes text fields, it makes sense to add a numeric hash code that can be checked by an ES query. We can use elastic search to find documents that share a value for hashCode and delete duplicates as necessary