### PR TITLE
add bldgID to hash

### DIFF
--- a/src/main/groovy/edu/oregonstate/mist/locations/core/Attributes.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/locations/core/Attributes.groovy
@@ -36,6 +36,7 @@ class Attributes extends ServiceAttributes {
         result = 31 * result + (address != null ? address.hashCode() : 0)
         result = 31 * result + (city != null ? city.hashCode() : 0)
         result = 31 * result + (telephone != null ? telephone.hashCode() : 0)
+        result = 31 * result + (bldgID != null ? bldgID.hashCode() : 0)
 
         Math.abs(result)
     }


### PR DESCRIPTION
The locations in question had unique bldgID's, so it made sense to add that field to the hashcode method.