### PR TITLE
Hotfix: always pull extension data from the cache

### DIFF
--- a/src/main/groovy/edu/oregonstate/mist/locations/LocationUtil.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/locations/LocationUtil.groovy
@@ -73,6 +73,25 @@ class LocationUtil {
     }
 
     /**
+     * Read data from a file in the cache directory.
+     *
+     * @param cachedFile the filename within the cache directory
+     * @return data
+     * @throws Exception
+     */
+    public String getCachedData(String cachedFile) {
+        def filePath = getFilePath(cachedFile)
+        // Check that cached file is within the current api directory
+        Path child = Paths.get(filePath).toAbsolutePath()
+        def parent = Paths.get(cacheDirectory).toAbsolutePath()
+        if (!child.startsWith(parent)) {
+            throw new Exception("Cache directory is outside of api directory")
+        }
+        def data = new File(filePath).getText()
+        data
+    }
+
+    /**
      * Returns path to file within cacheDirectory
      *
      * @param fileName

--- a/src/main/groovy/edu/oregonstate/mist/locations/db/ExtensionDAO.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/locations/db/ExtensionDAO.groovy
@@ -50,6 +50,8 @@ class ExtensionDAO {
     }
 
     private String getExtensionData() {
-        locationUtil.getDataFromUrlOrCache(extensionUrl, extensionXmlOut)
+        // Temporary fix for CO-1122: always pull from the cache, not the url
+        //locationUtil.getDataFromUrlOrCache(extensionUrl, extensionXmlOut)
+        locationUtil.getCachedData(extensionXmlOut)
     }
 }


### PR DESCRIPTION
CO-1122

This is hotfix for CO-1122. The extensions xml source that we were
pulling from disappeared, so always pull from the cache. A more
comprehensive fix is in the works as part of CO-955.