### PR TITLE
ignore unkown fields

### DIFF
--- a/src/main/groovy/edu/oregonstate/mist/locations/core/LibraryHours.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/locations/core/LibraryHours.groovy
@@ -1,10 +1,12 @@
 package edu.oregonstate.mist.locations.core
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
 
 /**
  * Represent the data that the library API returns
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 class LibraryHours {
     String open
     String close


### PR DESCRIPTION
the library added a new field which caused jackson to break because we weren't ignoring unknown fields