### PR TITLE
ignore non-public parking spaces

### DIFF
--- a/src/main/groovy/edu/oregonstate/mist/locations/db/LocationDAO.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/locations/db/LocationDAO.groovy
@@ -66,7 +66,10 @@ class LocationDAO {
             def propID = properties['Prop_ID']
             def parkingZoneGroup = properties['ZoneGroup']
 
-            if (isValidField(propID) && isValidField(parkingZoneGroup)) {
+            Boolean isValidParkingZoneGroup = isValidField(parkingZoneGroup) &&
+                    (parkingZoneGroup != "Non-Public")
+
+            if (isValidField(propID) && isValidParkingZoneGroup) {
                 parkingLocations.add(new ParkingLocation(it))
             } else {
                 ignoredParking.add(properties['OBJECTID'])


### PR DESCRIPTION
This commit ignores non-public spaces from arcgis. There were two non-public locations that shared same propID, and that should be our unique identifer. There isn't a need for getting non-public spaces from the locations API, so this commit removes all 22 of them from being outputted.